### PR TITLE
Repoint taps that have moved

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,6 @@
 cask_args appdir: "/Applications"
-tap "caskroom/cask"
-tap "caskroom/versions"
+tap "homebrew/cask-cask"
+tap "homebrew/cask-versions"
 tap "homebrew/cask-fonts"
 tap "heroku/brew"
 tap "holgerbrandl/tap"

--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,4 @@
 cask_args appdir: "/Applications"
-tap "homebrew/cask-cask"
 tap "homebrew/cask-versions"
 tap "homebrew/cask-fonts"
 tap "heroku/brew"


### PR DESCRIPTION
During strap process:

```
Error: caskroom/cask was moved. Tap homebrew/cask-cask instead.
Tapping caskroom/cask has failed!
Error: caskroom/versions was moved. Tap homebrew/cask-versions instead.
Tapping caskroom/versions has failed!
```